### PR TITLE
Added support for configurable extensions

### DIFF
--- a/Prettier.sublime-settings
+++ b/Prettier.sublime-settings
@@ -1,4 +1,5 @@
 {
+  "extensions": ["js", "jsx"],
   "autoformat": false,
   "printWidth": 80,
   "tabWidth": 2,

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ For example:
   // Turns on/off autoformatting on save
   "autoformat": true,
 
+  // Only attempt to format files with extensions set there
+  "extensions": ["js", "jsx"],
+
   // Fit code within this line limit
   "printWidth": 80,
 

--- a/prettier.py
+++ b/prettier.py
@@ -1,5 +1,6 @@
 import subprocess
 import platform
+import os
 from sublime import Region, load_settings
 import sublime_plugin
 
@@ -58,6 +59,13 @@ def prettify_code(edit, view, region):
 # Run prettier an a file
 class PrettierCommand(sublime_plugin.TextCommand):
     def run(self, edit):
+        extensions = settings.get('extensions')
+
+        # Check if the file extension is allowed
+        file_extension = os.path.splitext(self.view.file_name())[1][1:]
+        if extensions and not file_extension in extensions:
+            return
+
         region = Region(0, self.view.size())
         prettify_code(edit, self.view, region)
 

--- a/prettier.py
+++ b/prettier.py
@@ -63,7 +63,8 @@ class PrettierCommand(sublime_plugin.TextCommand):
 
         # Check if the file extension is allowed
         file_extension = os.path.splitext(self.view.file_name())[1][1:]
-        if extensions and not file_extension in extensions:
+        if extensions and file_extension not in extensions:
+            print('Prettier can\'t format .%s files' % file_extension)
             return
 
         region = Region(0, self.view.size())


### PR DESCRIPTION
Fixes #6 and #7

Hi!

Another PR from me today! This adds a configurable list of whitelisted extensions. I added it to the `prettier` command, but I was thinking that, maybe it should only be checked for the `autoformat`? 🤔 If a user manually enters the prettier command, we should probably let him run `prettier` on that file.

Let me know what you think.