### PR TITLE
Use settings from config if exists, fix trailingComma default value

### DIFF
--- a/Prettier.sublime-settings
+++ b/Prettier.sublime-settings
@@ -5,6 +5,6 @@
   "tabWidth": 2,
   "useFlowParser": false,
   "singleQuote": false,
-  "trailingComma": false,
+  "trailingComma": "none",
   "bracketSpacing": true
 }


### PR DESCRIPTION
Prettier config is ignored currently. This PR should solve this problem. Also I noticed, that options defaults contain `trailingCommand` in the old boolean format. Now it should be a string: https://prettier.io/docs/en/options.html#trailing-commas . Fixed it as well.