### PR TITLE
Update prettier options documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can add [custom key bindings](https://www.sublimetext.com/docs/3/settings.ht
 
 ## Configuration
 
-The plugin takes the same settings and the `prettier` tool. See the [`prettier` repo](https://github.com/jlongster/prettier/blob/master/src/options.js) or [this repo](https://github.com/danreeves/sublime-prettier/blob/master/Prettier.sublime-settings). You can configure them in Sublime at `Preferences > Package Settings > Prettier`.
+The plugin takes the same settings and the `prettier` tool. See the [`prettier` repo](https://github.com/jlongster/prettier/blob/master/docs/options.md) or [this repo](https://github.com/danreeves/sublime-prettier/blob/master/Prettier.sublime-settings). You can configure them in Sublime at `Preferences > Package Settings > Prettier`.
 
 You can turn on the auto formatting on save by setting `autoformat` to `true`.
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ ___
 
 # Prettier
 
-This is a Sublime Text 3 plugin for the [prettier](https://github.com/jlongster/prettier) JavaScript formatter.
+This is a Sublime Text 3 plugin for the [prettier](https://github.com/prettier/prettier) JavaScript formatter.
 
 ## Installation
 
-You need `prettier` installed globally for this plugin to work. See the [installation instructions](https://github.com/jlongster/prettier#usage).
+You need `prettier` installed globally for this plugin to work. See the [installation instructions](https://prettier.io/docs/en/install.html).
 
 `npm install -g prettier`
 
@@ -42,7 +42,7 @@ You can add [custom key bindings](https://www.sublimetext.com/docs/3/settings.ht
 
 ## Configuration
 
-The plugin takes the same settings and the `prettier` tool. See the [`prettier` repo](https://github.com/jlongster/prettier/blob/master/docs/options.md) or [this repo](https://github.com/danreeves/sublime-prettier/blob/master/Prettier.sublime-settings). You can configure them in Sublime at `Preferences > Package Settings > Prettier`.
+The plugin takes the same settings and the `prettier` tool. See the [`prettier` repo](https://github.com/prettier/prettier/blob/master/docs/options.md) or [this repo](https://github.com/danreeves/sublime-prettier/blob/master/Prettier.sublime-settings). You can configure them in Sublime at `Preferences > Package Settings > Prettier`.
 
 You can turn on the auto formatting on save by setting `autoformat` to `true`.
 


### PR DESCRIPTION
The current link is non existing, the proposed new link is a markdown file with nice formatting and examples.